### PR TITLE
[WPF] Align BoxView's Colors with other OSs.

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/BoxViewRenderer.cs
@@ -35,7 +35,8 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void UpdateColor()
 		{
-			Control.UpdateDependencyColor(WRectangle.FillProperty, Element.Color);
+			Color color = Element.Color != Color.Default ? Element.Color : Element.BackgroundColor;
+			Control.UpdateDependencyColor(WRectangle.FillProperty, color);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Fixes an issue where the BoxView doesnt pickup the BackgroundColor if it was set rather than the Color property.
*No Tests

### Bugs Fixed ###

No Link

### API Changes ###

None

### Behavioral Changes ###

BoxView will now show it's color if the BackgroundColor was used instead of Color.  This brings it in line with the other OS's.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
