### PR TITLE
[WPF] Open up color extensions.

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/ColorExtensions.cs
@@ -7,7 +7,7 @@ using System.Windows.Media;
 
 namespace Xamarin.Forms.Platform.WPF
 { 
-	internal static class ColorExtensions
+	public static class ColorExtensions
 	{
 		public static Brush ToBrush(this Color color)
 		{

--- a/Xamarin.Forms.Platform.WPF/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/ColorExtensions.cs
@@ -7,7 +7,7 @@ using System.Windows.Media;
 
 namespace Xamarin.Forms.Platform.WPF
 { 
-	public static class ColorExtensions
+	internal static class ColorExtensions
 	{
 		public static Brush ToBrush(this Color color)
 		{


### PR DESCRIPTION
### Description of Change ###

Opened up the useful WPF color extensions for use on custom controls and renderers.
*No Tests

### Bugs Fixed ###

No Link

### API Changes ###

None

### Behavioral Changes ###

Developers can now use the ColorExtensions ToMediaColor and ToBrush.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
