### PR TITLE
[WPF] Border's show incorrectly at times.

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/FrameRenderer.cs
@@ -61,8 +61,16 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void UpdateBorder()
 		{
-			Control.UpdateDependencyColor(Border.BorderBrushProperty, Element.OutlineColor);
-			Control.BorderThickness = new System.Windows.Thickness(1);
+			if (Element.OutlineColor != Color.Default)
+			{
+				Control.UpdateDependencyColor(Border.BorderBrushProperty, Element.OutlineColor);
+				Control.BorderThickness = new System.Windows.Thickness(1);
+			}
+			else
+			{
+				Control.UpdateDependencyColor(Border.BorderBrushProperty, new Color(0, 0, 0, 0));
+				Control.BorderThickness = new System.Windows.Thickness(0);
+			}
 		}
 
 		void UpdateCornerRadius()


### PR DESCRIPTION
### Description of Change ###

Fixes an issue where the Border would not default correctly when a border did not exist.

*No Tests

### Bugs Fixed ###

No Link

### API Changes ###

None

### Behavioral Changes ###

Borders will now show correctly if a border was disabled.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
