### PR TITLE
[WPF] EntryRenderer would throw null references.

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
@@ -108,7 +108,8 @@ namespace Xamarin.Forms.Platform.WPF
 			if (Control.Text != entryText)
 			{
 				Control.Text = entryText;
-				Control.SelectionStart = Control.Text.Length;
+				if (Control.Text != null)
+					Control.SelectionStart = Control.Text.Length;
 			}
 
 			_ignoreTextChange = false;
@@ -224,7 +225,7 @@ namespace Xamarin.Forms.Platform.WPF
 				return;
 
 			Control.Text = Element.Text ?? "";
-			Control.Select(Control.Text.Length, 0);
+			Control.Select(Control.Text == null ? 0 : Control.Text.Length, 0);
 		}
 
 		bool _isDisposed;


### PR DESCRIPTION
### Description of Change ###

Fixes an issue where the EntryRenderer would throw null references when the Text was Null.

*No Tests

### Bugs Fixed ###

No Link

### API Changes ###

None

### Behavioral Changes ###

Entry should now render without null references on null Text.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
