### PR TITLE
[WPF] Taps are inverted on the tree.

### DIFF
--- a/Xamarin.Forms.Platform.WPF/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WPF/VisualElementTracker.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 				if (_control != null)
 				{
-					_control.PreviewMouseLeftButtonDown -= PreviewMouseLeftButtonDown;
+					_control.MouseLeftButtonUp -= MouseLeftButtonUp;
 					_control.ManipulationDelta -= OnManipulationDelta;
 					_control.ManipulationCompleted -= OnManipulationCompleted;
 				}
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 				if (_control != null)
 				{
-					_control.PreviewMouseLeftButtonDown += PreviewMouseLeftButtonDown;
+					_control.MouseLeftButtonUp += MouseLeftButtonUp;
 					_control.ManipulationDelta += OnManipulationDelta;
 					_control.ManipulationCompleted += OnManipulationCompleted;
 				}
@@ -90,16 +90,14 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 		}
 
-		private void PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+		private void MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
 		{
 			var fe = (sender as FrameworkElement);
 			var vr = (sender as DefaultViewRenderer)?.Element;
 
 			if ((fe != null && !fe.IsEnabled) || (vr != null && !vr.IsEnabled))
-			{
-				e.Handled = true;
 				return;
-			}
+
 			e.Handled = ElementOnTap(e.ClickCount);
 		}
 		
@@ -317,7 +315,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 			if (_control != null)
 			{
-				_control.PreviewMouseLeftButtonDown -= PreviewMouseLeftButtonDown;
+				_control.MouseLeftButtonUp -= MouseLeftButtonUp;
 				_control.ManipulationDelta -= OnManipulationDelta;
 				_control.ManipulationCompleted -= OnManipulationCompleted;
 			}


### PR DESCRIPTION
### Description of Change ###

Fixes an issue where the left mouse(tap) was inverted on the tree.  I switched the Preview(parent-to-child) to Standard(child-to-parent).

*No Tests

### Bugs Fixed ###

No Link

### API Changes ###

None

### Behavioral Changes ###

Taps should work correctly now when controls in the tree both attach to tap events.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Consolidate commits as makes sense
